### PR TITLE
scripts: add a script to upload build artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: release
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build Release
+      run: ./scripts/build-release.sh
+    - name: Update Dependencies
+      run: sudo apt-get update
+    - name: Install Dependencies
+      run: sudo apt-get install -y jq
+    - name: Upload
+      run: ./scripts/release.sh ./bin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,5 +1,19 @@
 #!/bin/bash -e
 
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # A script for building binary releases for various platforms.
 
 if [[ "$0" != "./scripts/build-release.sh" ]]; then
@@ -8,6 +22,10 @@ if [[ "$0" != "./scripts/build-release.sh" ]]; then
 fi
 
 VERSION="$1"
+
+if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+	VERSION="$GITHUB_REF_NAME"
+fi
 
 if [[ "$VERSION" != v* ]]; then
 	1>&2 echo "No version specified as argument"
@@ -48,6 +66,8 @@ function build {
 	fi
 	rm -rf "$TEMP_DIR"
 }
+
+# NOTE: When adding new releases, also update .github/workflows/release.yaml.
 
 build darwin amd64
 build darwin arm64

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables
+
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+	2>&1 echo "GITHUB_TOKEN not present"
+	exit 1
+fi
+
+if [[ "$GITHUB_REF_NAME" == "" ]]; then
+	2>&1 echo "GITHUB_REF_NAME not present"
+	exit 1
+fi
+
+if [[ "$GITHUB_API_URL" == "" ]]; then
+	2>&1 echo "GITHUB_API_URL not present"
+	exit 1
+fi
+
+if [[ "$GITHUB_REPOSITORY" == "" ]]; then
+	2>&1 echo "GITHUB_REPOSITORY not present"
+	exit 1
+fi
+
+if [[ "$1" == "" ]]; then
+	2>&1 echo "No files to upload"
+	exit 1
+fi 
+
+AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
+
+TEMP_DIR="$( mktemp -d )"
+
+# https://docs.github.com/en/rest/reference/releases#get-a-release-by-tag-name
+
+curl -sSL \
+	--fail \
+	--header "$AUTH_HEADER" \
+	-o "${TEMP_DIR}/out" \
+	"${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" 
+
+RELEASE_ID="$( jq '.id' < "${TEMP_DIR}/out" )"
+
+echo "Release ID: ${RELEASE_ID}"
+
+# https://docs.github.com/en/rest/reference/releases#upload-a-release-asset
+
+for FILE in ${1}/*
+do
+	echo $FILE
+	NAME="${FILE#$1}"
+	if [[ "$NAME" != "/" && "$NAME" != "" ]]; then
+	    echo "Uploading: ${NAME}"
+		RELEASE_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${NAME}"
+		echo "Upload URL: ${RELEASE_URL}"
+		curl -sSL \
+			-o - \
+			-XPOST \
+			--fail \
+			--header "$AUTH_HEADER" \
+			--header "Content-Type: application/octet-stream" \
+			--upload-file "$FILE" \
+			"$RELEASE_URL"
+	fi
+done
+
+rm -rf "$TEMP_DIR"


### PR DESCRIPTION
Tested on my fork:
- https://github.com/ericchiang/log4jscanner/actions/runs/1635339462
- https://github.com/ericchiang/log4jscanner/releases/tag/v0.1.0

```
$ wget https://github.com/ericchiang/log4jscanner/releases/download/v0.1.0/log4jscanner-v0.1.0-linux-amd64.tar.gz
# ...
$ tar -zxvf log4jscanner-v0.1.0-linux-amd64.tar.gz
./
./log4jscanner/
./log4jscanner/log4jscanner
$ ./log4jscanner/log4jscanner --help
Usage: log4jscanner [flag] [directories]

A log4j vulnerability scanner. The scanner walks the provided directories
attempting to find vulnerable JARs. Paths of vulnerable JARs are printed
to stdout.

Flags:

    -s, --skip     Glob pattern to skip when scanning (e.g. '/var/run/*'). May
                   be provided multiple times.
    -w, --rewrite  Rewrite vulnerable JARs as they are detected.
    -v, --verbose  Print verbose logs to stderr.


```

Updates https://github.com/google/log4jscanner/issues/7
