### PR TITLE
jar: iterate over zip file headers instead of using fs.WalkDir

### DIFF
--- a/jar/jar_test.go
+++ b/jar/jar_test.go
@@ -70,7 +70,7 @@ func TestParse(t *testing.T) {
 				t.Fatalf("zip.OpenReader failed: %v", err)
 			}
 			defer zr.Close()
-			report, err := Parse(zr)
+			report, err := Parse(&zr.Reader)
 			if err != nil {
 				t.Fatalf("Scan() returned an unexpected error, got %v, want nil", err)
 			}
@@ -92,7 +92,7 @@ func BenchmarkParse(b *testing.B) {
 	defer zr.Close()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err := Parse(zr)
+		_, err := Parse(&zr.Reader)
 		if err != nil {
 			b.Errorf("Scan() returned an unexpected error, got %v, want nil", err)
 		}


### PR DESCRIPTION
Avoid some of the edge cases we've hit when combining archive/zip and
fs.WalkDir and iterate over the ZIP files directly. Lets us drop some
workarounds.

Negative is that we have to break a public API, but hopefully that's
okay while we're pre v1.0.0.

PR attempts to make the diff as small as possible.

https://github.com/google/log4jscanner/issues/12
https://github.com/golang/go/issues/50390
https://github.com/golang/go/issues/50179