### PR TITLE
Fix bug where directories inside rewritten jars had incorrect lengths

### DIFF
--- a/jar/rewrite.go
+++ b/jar/rewrite.go
@@ -122,8 +122,8 @@ func Rewrite(w io.Writer, zr *zip.Reader) error {
 
 	copyFile:
 		if zipItem.Mode().IsDir() {
-			// Copy() only works on files.
-			if _, err := zw.CreateRaw(&zipItem.FileHeader); err != nil {
+			// Copy() only works on files, so manually create the directory entry
+			if _, err := zw.CreateHeader(&zipItem.FileHeader); err != nil {
 				return fmt.Errorf("failed to copy zip directory %s: %v", zipItem.Name, err)
 			}
 		} else {


### PR DESCRIPTION
Previously, when patching certain jars the length calculations were slightly off due to our usage of CreateRaw to create zip headers to represent empty directories. These slight errors don't seem to actually break the jars from java's perspective, java still opens them fine. But Finder on MacOS complains that they are invalid if someone tries to open them as a zip. Inspecting them with `zipinfo -v` shows a number of warnings along the lines of "There are an extra -2 bytes preceding this file".

This PR fixes this by using CreateHeader instead of CreateRaw. I also added tests to ensure that this corruption doesn't happen again.