### PR TITLE
Note that we flag the java 6 and 7 versions as vulnerable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ JARs automatically or taking other mitigations based on scan results.
 
 If you do hit a false positive, please open an issue.
 
+Note: This scanner purposefully flags the patched versions of log4j for Java 6
+and Java 7 as vulnerable (v2.12.3+ and v2.3.1+). 
+
 ## Contributors
 
 We unfortunately had to squash the history when open sourcing. The following

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ JARs automatically or taking other mitigations based on scan results.
 If you do hit a false positive, please open an issue.
 
 Note: This scanner purposefully flags the patched versions of log4j for Java 6
-and Java 7 as vulnerable (v2.12.3+ and v2.3.1+). 
+and Java 7 as vulnerable. 
 
 ## Contributors
 


### PR DESCRIPTION
Fixes #43