### PR TITLE
Add version control directories in skipDirs

### DIFF
--- a/log4jscanner.go
+++ b/log4jscanner.go
@@ -49,6 +49,8 @@ var skipDirs = map[string]bool{
 	".git":         true,
 	"node_modules": true,
 	".idea":        true,
+	".svn":			true,
+	".p4root":		true,
 
 	// TODO(ericchiang): expand
 }


### PR DESCRIPTION
This PR add subversion (.svn) and perforce (.p4root) directory pattern at skipDirs.