### PR TITLE
scripts: don't include '.' in the release TAR file

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -56,13 +56,16 @@ function build {
 		zip -r "$TARGET" ./
 		cd -
 	else
+		TARGET="${PWD}/bin/log4jscanner-${VERSION}-${GOOS}-${GOARCH}.tar.gz"
 		tar \
 			--group=root \
 			--owner=root \
 			-czvf \
-			"${PWD}/bin/log4jscanner-${VERSION}-${GOOS}-${GOARCH}.tar.gz" \
+			"$TARGET" \
 			-C "$TEMP_DIR" \
-			"./"
+			"./log4jscanner"
+		# Print the contents of the TAR so we can visually debug it during CI.
+		tar -ztvf "$TARGET"
 	fi
 	rm -rf "$TEMP_DIR"
 }


### PR DESCRIPTION
Also print the contents of the file after building to help debugging.

Fixes https://github.com/google/log4jscanner/issues/46