### PR TITLE
jar: reduce redundant allocations and copies (2x-3x speedup)

### DIFF
--- a/jar/jar.go
+++ b/jar/jar.go
@@ -385,8 +385,8 @@ func (c *checker) checkFile(zf *zip.File, depth int, size int64, jar string) err
 	if err != nil {
 		return fmt.Errorf("open file %s: %v", p, err)
 	}
-	defer f.Close()
 	data, err := io.ReadAll(f)
+	f.Close() // Recycle the flate buffer earlier, we're going to recurse.
 	if err != nil {
 		return fmt.Errorf("read file %s: %v", p, err)
 	}

--- a/jar/jar_test.go
+++ b/jar/jar_test.go
@@ -207,39 +207,51 @@ func TestInfiniteRecursion(t *testing.T) {
 }
 
 func BenchmarkParse(b *testing.B) {
-	filename := "safe1.jar"
-	p := testdataPath(filename)
-	zr, _, err := OpenReader(p)
-	if err != nil {
-		b.Fatalf("zip.OpenReader failed: %v", err)
-	}
-	defer zr.Close()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := Parse(&zr.Reader)
-		if err != nil {
-			b.Errorf("Scan() returned an unexpected error, got %v, want nil", err)
-		}
+	for _, filename := range [...]string{
+		"400mb_jar_in_jar.jar",
+		"safe1.jar",
+	} {
+		b.Run(filename, func(b *testing.B) {
+			p := testdataPath(filename)
+			zr, _, err := OpenReader(p)
+			if err != nil {
+				b.Fatalf("zip.OpenReader failed: %v", err)
+			}
+			defer zr.Close()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := Parse(&zr.Reader)
+				if err != nil {
+					b.Errorf("Scan() returned an unexpected error, got %v, want nil", err)
+				}
+			}
+		})
 	}
 }
 
 func BenchmarkParseParallel(b *testing.B) {
-	filename := "safe1.jar"
-	p := testdataPath(filename)
-	b.ReportAllocs()
-	b.RunParallel(func(pb *testing.PB) {
-		zr, _, err := OpenReader(p)
-		if err != nil {
-			b.Fatalf("zip.OpenReader failed: %v", err)
-		}
-		defer zr.Close()
-		for pb.Next() {
-			_, err := Parse(&zr.Reader)
-			if err != nil {
-				b.Errorf("Scan() returned an unexpected error, got %v, want nil", err)
-			}
-		}
-	})
+	for _, filename := range [...]string{
+		"400mb_jar_in_jar.jar",
+		"safe1.jar",
+	} {
+		b.Run(filename, func(b *testing.B) {
+			p := testdataPath(filename)
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				zr, _, err := OpenReader(p)
+				if err != nil {
+					b.Fatalf("zip.OpenReader failed: %v", err)
+				}
+				defer zr.Close()
+				for pb.Next() {
+					_, err := Parse(&zr.Reader)
+					if err != nil {
+						b.Errorf("Scan() returned an unexpected error, got %v, want nil", err)
+					}
+				}
+			})
+		})
+	}
 }
 
 func TestLog4jPattern(t *testing.T) {

--- a/pool/dynamic.go
+++ b/pool/dynamic.go
@@ -1,0 +1,67 @@
+// Package pool provides an object pool that trades off the cost of creation
+// versus retention. It is meant to avoid the pessimal behaviour (see [issue
+// 23199]) seen when using a regular sync.Pool with objects of dynamic sizes;
+// objects that are too large are kept alive by repeat usages that don't need
+// such sizes.
+//
+// [issue 23199]: https://github.com/golang/go/issues/23199
+package pool
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+)
+
+// A Dynamic pool is like a sync.Pool for objects of varying sizes.
+//
+// It prevents the indefinite retention of (too) large objects by keeping a
+// history of required object sizes (utility) and comparing them to the actual
+// object size (cost) before accepting an object.
+type Dynamic struct {
+	Pool sync.Pool
+
+	// The utility below which the cost of creating the object is more expensive
+	// than just keeping it. Set this to the expected object size (or perhaps a
+	// bit larger to reduce allocations more).
+	MinUtility float64
+
+	avgUtility uint64 // Actually a float64, but that type does not have atomic ops.
+}
+
+func (p *Dynamic) Get() interface{} {
+	return p.Pool.Get()
+}
+
+// Put is like sync.Pool.Put, with a few differences. The utility is a measure
+// of what part of the object was actually used. The cost is a measure of the
+// total "size" of the object. Utility must be smaller than or equal to cost.
+func (p *Dynamic) Put(v interface{}, utility, cost float64) bool {
+	// Update the average utility. Uses atomic load/store, which means that
+	// values can get lost if Put is called concurrently. That's fine, we're
+	// just looking for an approximate (weighted) moving average.
+	avgUtility := math.Float64frombits(atomic.LoadUint64(&p.avgUtility))
+	avgUtility = decay(avgUtility, utility, p.MinUtility)
+	atomic.StoreUint64(&p.avgUtility, math.Float64bits(avgUtility))
+
+	if cost > 10*avgUtility {
+		return false // If the cost is 10x larger than the average utility, drop it.
+	}
+	p.Pool.Put(v)
+	return true
+}
+
+// decay updates returns `val` if `val > `prev`, otherwise it returns an
+// exponentially moving average of `prev` and `val` (with factor 0.5. This is
+// meant to provide a slower downramp if `val` drops ever lower. The minimum
+// value is `min`.
+func decay(prev, val, min float64) float64 {
+	if val < min {
+		val = min
+	}
+	if prev == 0 || val > prev {
+		return val
+	}
+	const factor = 0.5
+	return (prev * factor) + (val * (1 - factor))
+}

--- a/pool/dynamic_test.go
+++ b/pool/dynamic_test.go
@@ -1,0 +1,80 @@
+package pool
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+const bufSize = 4096
+
+// The desired behaviour of the dynamic (buffer) pool is:
+//   - Don't retain (very) large items indefinitely (check that one is rejected
+//     at least once).
+//   - Do retain even large items for a while so their allocation cost is
+//     amortized.
+func TestDynamic(t *testing.T) {
+	dp := Dynamic{
+		Pool:       sync.Pool{New: func() interface{} { return make([]byte, 0) }},
+		MinUtility: bufSize,
+	}
+	var allocs int
+	// Simulate a sequence of file sizes. This sequence is not based on some
+	// real-life observed sequence of sizes of jar-in-jars. It might be better
+	// to use such a sequence, but every organisation will have its own expected
+	// sizes and this synthetic one conains some fairly extreme samples that
+	// check whether the algorithm is robust.
+	//
+	// For the current algorithm, the worst possible sequence is one that
+	// rises, then suddenly drops and then rises slowly again. We contend that
+	// this case is rare.
+	sizes := [...]int{
+		100000, 1, 1, 1, 1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1,
+		1000, 100, 10000, 100000, 1, 100000, 1, 50000, 1, 1, 25000, 1, 1, 1,
+		100000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 100, 100, 100, 1, 1, 1, 1, 1, 100,
+		200, 300, 100, 50, 50, 50, 50, 50, 1, 1, 1, 1, 100000000, 1000000,
+		100000, 10000, 1000, 100, 10, 1, 1, 500, 2020, 400, 3984, 5, 200, 500,
+		40000, 35000, 45000, 42000, 38000, 38000, 39000, 41000, 42000, 42000, // Average: 40000
+		2000, 4000, 3949, 2011, 4096, 33, 0, 4938, 1, 1, 1200, 2400, 1200, 200,
+		400, 600, 700, 100, 400, 500, 700, 600, 900, 1000, 1100, 1200, 1000,
+	}
+
+	var largeBufferPurged int
+
+	t.Logf("num allocs value target capacity")
+	// This test assumes (with some margin for error) that back-to-back Put/Get
+	// on a pool from a single goroutine yield the same item. I believe this to
+	// be a fairly stable assumption avoiding plenty of testing boilerplate,
+	// time will tell.
+	for idx, size := range sizes {
+		buf := dp.Get().([]byte)
+		if cap(buf) < size {
+			capacity := size
+			if capacity < bufSize {
+				capacity = bufSize // Allocating much smaller buffers could lead to quick re-allocations.
+			}
+			buf = make([]byte, size, capacity)
+			allocs++
+		} else {
+			buf = buf[:size]
+		}
+		utility := float64(len(buf))
+		if utility < bufSize {
+			utility = bufSize
+		}
+		if !dp.Put(buf, utility, float64(cap(buf))) && cap(buf) >= 100000 {
+			largeBufferPurged++
+		}
+		avgUtility := math.Float64frombits(atomic.LoadUint64(&dp.avgUtility))
+		t.Logf("%d %d %d %f %d", idx+1, allocs, size, avgUtility, cap(buf))
+	}
+	// Before the amortized buffer optimization, each iteration would've been
+	// one allocation. We want at least 10x fewer than that.
+	if got, want := allocs, len(sizes)/10; got > want {
+		t.Errorf("got %d allocations, wanted %d", got, want)
+	}
+	if got, atLeast := largeBufferPurged, 2; got < atLeast {
+		t.Errorf("buffers >= 100000 have been rejected %d times, expected at least %d", got, atLeast)
+	}
+}


### PR DESCRIPTION
The io.ReadAll() call is responsible for a bit more than half the allocations observed in a very highly scaled up instance of this [1]. On the local testdata, these commits had quite the positive effect. I ran `go test` inside the jar/ subdirectory too, and it passed.

Benchmarks:

```
$ for commit in $(git log --pretty=oneline | head -4 | awk '{print $1}' | tac) ; do
    git checkout $commit
    go build
    hyperfine -i './log4jscanner jar/testdata'
    rm log4jscanner
  done

HEAD is now at https://github.com/aktau/log4jscanner/commit/9d3aceeff48dc332d314d938ef6f3ed7837dfc1e Document commit that removed InitialContext
  Time (mean ± σ):      1.754 s ±  0.260 s    [User: 1.711 s, System: 1.264 s]
  Range (min … max):    1.411 s …  2.182 s    10 runs

HEAD is now at https://github.com/aktau/log4jscanner/commit/2932093ea7873a0df400ec12980ed6206b120ad7 jar: close the zip.File reader before recursing
  Time (mean ± σ):      1.761 s ±  0.312 s    [User: 1.778 s, System: 1.124 s]
  Range (min … max):    1.271 s …  2.239 s    10 runs

HEAD is now at https://github.com/aktau/log4jscanner/commit/f6c1ebcfb928f724f174e9c8ccd818534840a10a jar: prefer io.ReadFull over io.ReadAll
  Time (mean ± σ):     444.8 ms ±  95.3 ms    [User: 353.5 ms, System: 122.3 ms]
  Range (min … max):   337.2 ms … 683.2 ms    10 runs

HEAD is now at 5a28952 jar: reuse buffers for nested .jar's
  Time (mean ± σ):     398.0 ms ±  44.7 ms    [User: 330.6 ms, System: 89.9 ms]
  Range (min … max):   339.7 ms … 471.1 ms    10 runs
```

[1]:

```
(pprof) list checkJAR
Total: 213.06GB
         ...
         .     9.89MB    334:           f, err := zf.Open()
         .          .    335:           if err != nil {
         .          .    336:                   return fmt.Errorf("open file %s: %v", p, err)
         .          .    337:           }
         .          .    338:           defer f.Close()
         .   169.96GB    339:           data, err := io.ReadAll(f)
         .          .    340:           if err != nil {
         .          .    341:                   return fmt.Errorf("read file %s: %v", p, err)
         .          .    342:           }
         .          .    343:           br := bytes.NewReader(data)
         .     3.40GB    344:           r2, err := zip.NewReader(br, br.Size())
         ...

(pprof) list ReadAll
Total: 213.06GB
ROUTINE ======================== io.ReadAll in third_party/go/gc/src/io/io.go
  113.40GB   169.96GB (flat, cum) 79.77% of Total
         .          .    638:func ReadAll(r Reader) ([]byte, error) {
         .          .    639:   b := make([]byte, 0, 512)
         .          .    640:   for {
         .          .    641:           if len(b) == cap(b) {
         .          .    642:                   // Add more capacity (let append pick how much).
  113.40GB   113.40GB    643:                   b = append(b, 0)[:len(b)]
         .          .    644:           }
         .    56.56GB    645:           n, err := r.Read(b[len(b):cap(b)])
         .          .    646:           b = b[:len(b)+n]
         .          .    647:           if err != nil {
         .          .    648:                   if err == EOF {
         .          .    649:                           err = nil
         .          .    650:                   }
```