### PR TITLE
jar: fix pool.Dynamic test flakiness

### DIFF
--- a/jar/jar.go
+++ b/jar/jar.go
@@ -257,7 +257,7 @@ var (
 		},
 	}
 	dynBufPool = pool.Dynamic{
-		Pool:       sync.Pool{New: func() interface{} { return make([]byte, 0) }},
+		Pool:       &sync.Pool{New: func() interface{} { return make([]byte, 0) }},
 		MinUtility: bufSize,
 	}
 )

--- a/pool/dynamic.go
+++ b/pool/dynamic.go
@@ -9,7 +9,6 @@ package pool
 
 import (
 	"math"
-	"sync"
 	"sync/atomic"
 )
 
@@ -19,7 +18,10 @@ import (
 // history of required object sizes (utility) and comparing them to the actual
 // object size (cost) before accepting an object.
 type Dynamic struct {
-	Pool sync.Pool
+	Pool interface {
+		Get() interface{}
+		Put(interface{})
+	}
 
 	// The utility below which the cost of creating the object is more expensive
 	// than just keeping it. Set this to the expected object size (or perhaps a


### PR DESCRIPTION
The test flakiness is due to the sync.Pool sometimes forgetting values,
when there is GC pressure. This is part of the stated behaviour of a
pool, I just though this single test would always respond the same way
given the same GOGC. That was, of course, overly optimistic. It shows me
I shouldn't rely on a `sync.Pool` behaving "simply" even for single
goroutine cases. There's two options:

 1. Only rely on the return value of Put() for tests (though this would
    weaken the test a bit).
 2. Use a simpler pool for tests, which doesn't forget values.

I've chosen option #2.