### PR TITLE
jar: support Go 1.19 archive/zip

### DIFF
--- a/jar/jar.go
+++ b/jar/jar.go
@@ -211,15 +211,14 @@ func (o offsetReader) ReadAt(p []byte, off int64) (n int, err error) {
 // - https://kevinboone.me/execjava.html
 // - https://github.com/golang/go/issues/10464
 func NewReader(ra io.ReaderAt, size int64) (zr *zip.Reader, offset int64, err error) {
-	zr, err = zip.NewReader(ra, size)
-	if err == nil || !errors.Is(err, zip.ErrFormat) {
-		return zr, 0, err
-	}
 	offset, err = zipfork.ReadZIPOffset(ra, size)
 	if err != nil {
 		return nil, 0, err
 	}
-	zr, err = zip.NewReader(offsetReader{ra, offset}, size-offset)
+	if offset > 0 {
+		ra = offsetReader{ra, offset}
+	}
+	zr, err = zip.NewReader(ra, size)
 	return zr, offset, err
 }
 


### PR DESCRIPTION
In Go 1.19 the standard library's archive/zip package will
automatically and silently handle a prefixed zip file.
The log4jscanner package expects to handle the offset itself.
To let log4jscanner work with both Go 1.18 and 1.19,
change it to read the offset first, before using the archive/zip
package.

Tested by running tests with both Go 1.18 and Go tip.
Without this change, Go tip fails with
--- FAIL: TestAutoMitigateExecutable (0.00s)
    --- FAIL: TestAutoMitigateExecutable/helloworld-executable (0.00s)
        rewrite_test.go:247: expected offset for executable testdata/helloworld-executable: got=0
    --- FAIL: TestAutoMitigateExecutable/vuln-class-executable (0.00s)
        rewrite_test.go:247: expected offset for executable testdata/vuln-class-executable: got=0
FAIL
FAIL	github.com/google/log4jscanner/jar	34.541s